### PR TITLE
center the board game to the middle of the screen

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -18,6 +18,11 @@ h2 {
     margin: 30px auto 0 auto;
 }
 
+.board-container {
+    display: flex;
+    justify-content: center;;
+}
+
 .tile {
     cursor: pointer;
     width: 40px;

--- a/src/components/Minesweeper.vue
+++ b/src/components/Minesweeper.vue
@@ -4,7 +4,7 @@
         <h1 class="text-4xl text-center">{{ displayClassicEmoji }}</h1>
         <div class="mx-auto text-center mt-8">
 
-            <div v-for="(tilesRow, indexRow) in tiles" :key="indexRow">
+            <div v-for="(tilesRow, indexRow) in tiles" :key="indexRow" class="board-container">
                 <div v-for="(tile, index) in tilesRow" :key="index">
                     <tile
                             :x="tile.x"


### PR DESCRIPTION
This is meant to fix issue, #3 . By adding a class to the board container, and then styling that with Flexbox to justify the content center, I was able to center the board